### PR TITLE
Fix build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ server:	$(OBJS)
 
 runtime/generic/base.dll:	.obj/base.o
 	$(CC) $(DDFLAGS) -o base.tmp .obj/base.o
+	@mkdir -p runtime/generic
 	@mv base.tmp runtime/generic/base.dll
 
 .obj/base.o:		base.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -240,6 +241,7 @@ runtime/generic/base.dll:	.obj/base.o
 
 runtime/generic/sidestory.dll:	.obj/sidestory.o
 	$(CC) $(DDFLAGS) -o sidestory.tmp .obj/sidestory.o
+	@mkdir -p runtime/generic
 	@mv sidestory.tmp runtime/generic/sidestory.dll
 
 .obj/sidestory.o:		sidestory.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -247,6 +249,7 @@ runtime/generic/sidestory.dll:	.obj/sidestory.o
 
 runtime/generic/pents.dll:	.obj/pents.o
 	$(CC) $(DDFLAGS) -o pents.tmp .obj/pents.o
+	@mkdir -p runtime/generic
 	@mv pents.tmp runtime/generic/pents.dll
 
 .obj/pents.o:		pents.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -254,6 +257,7 @@ runtime/generic/pents.dll:	.obj/pents.o
 
 runtime/generic/professor.dll:	.obj/professor.o
 	$(CC) $(DDFLAGS) -o professor.tmp .obj/professor.o
+	@mkdir -p runtime/generic
 	@mv professor.tmp runtime/generic/professor.dll
 
 .obj/professor.o:		professor.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -261,6 +265,7 @@ runtime/generic/professor.dll:	.obj/professor.o
 
 runtime/generic/bank.dll:	.obj/bank.o
 	$(CC) $(DDFLAGS) -o bank.tmp .obj/bank.o
+	@mkdir -p runtime/generic
 	@mv bank.tmp runtime/generic/bank.dll
 
 .obj/bank.o:		bank.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -268,6 +273,7 @@ runtime/generic/bank.dll:	.obj/bank.o
 
 runtime/generic/alchemy.dll:	.obj/alchemy.o
 	$(CC) $(DDFLAGS) -o alchemy.tmp .obj/alchemy.o
+	@mkdir -p runtime/generic
 	@mv alchemy.tmp runtime/generic/alchemy.dll
 
 .obj/alchemy.o:		alchemy.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -275,6 +281,7 @@ runtime/generic/alchemy.dll:	.obj/alchemy.o
 
 runtime/generic/book.dll:	.obj/book.o
 	$(CC) $(DDFLAGS) -o book.tmp .obj/book.o
+	@mkdir -p runtime/generic
 	@mv book.tmp runtime/generic/book.dll
 
 .obj/book.o:		book.c server.h book.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -282,6 +289,7 @@ runtime/generic/book.dll:	.obj/book.o
 
 runtime/generic/transport.dll:	.obj/transport.o
 	$(CC) $(DDFLAGS) -o transport.tmp .obj/transport.o
+	@mkdir -p runtime/generic
 	@mv transport.tmp runtime/generic/transport.dll
 
 .obj/transport.o:		transport.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -289,6 +297,7 @@ runtime/generic/transport.dll:	.obj/transport.o
 
 runtime/generic/clanmaster.dll:	.obj/clanmaster.o
 	$(CC) $(DDFLAGS) -o clanmaster.tmp .obj/clanmaster.o
+	@mkdir -p runtime/generic
 	@mv clanmaster.tmp runtime/generic/clanmaster.dll
 
 .obj/clanmaster.o:		clanmaster.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -296,6 +305,7 @@ runtime/generic/clanmaster.dll:	.obj/clanmaster.o
 
 runtime/generic/clubmaster.dll:	.obj/clubmaster.o
 	$(CC) $(DDFLAGS) -o clubmaster.tmp .obj/clubmaster.o
+	@mkdir -p runtime/generic
 	@mv clubmaster.tmp runtime/generic/clubmaster.dll
 
 .obj/clubmaster.o:		clubmaster.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h map.h create.h container.h tool.h spell.h effect.h light.h los.h
@@ -303,6 +313,7 @@ runtime/generic/clubmaster.dll:	.obj/clubmaster.o
 
 runtime/generic/lostcon.dll:	.obj/lostcon.o
 	$(CC) $(DDFLAGS) -o lostcon.tmp .obj/lostcon.o
+	@mkdir -p runtime/generic
 	@mv lostcon.tmp runtime/generic/lostcon.dll
 
 .obj/lostcon.o:		lostcon.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h player.h
@@ -310,6 +321,7 @@ runtime/generic/lostcon.dll:	.obj/lostcon.o
 
 runtime/generic/merchant.dll:	.obj/merchant.o
 	$(CC) $(DDFLAGS) -o merchant.tmp .obj/merchant.o
+	@mkdir -p runtime/generic
 	@mv merchant.tmp runtime/generic/merchant.dll
 
 .obj/merchant.o:	merchant.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h
@@ -317,6 +329,7 @@ runtime/generic/merchant.dll:	.obj/merchant.o
 
 runtime/generic/simple_baddy.dll:	.obj/simple_baddy.o
 	$(CC) $(DDFLAGS) -o simple_baddy.tmp .obj/simple_baddy.o
+	@mkdir -p runtime/generic
 	@mv simple_baddy.tmp runtime/generic/simple_baddy.dll
 
 .obj/simple_baddy.o:		simple_baddy.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h
@@ -324,6 +337,7 @@ runtime/generic/simple_baddy.dll:	.obj/simple_baddy.o
 
 runtime/1/gwendylon.dll:	.obj/gwendylon.o
 	$(CC) $(DDFLAGS) -o gwendylon.tmp .obj/gwendylon.o
+	@mkdir -p runtime/1
 	@mv gwendylon.tmp runtime/1/gwendylon.dll
 
 .obj/gwendylon.o:	gwendylon.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -331,6 +345,7 @@ runtime/1/gwendylon.dll:	.obj/gwendylon.o
 
 runtime/1/shrike.dll:	.obj/shrike.o
 	$(CC) $(DDFLAGS) -o shrike.tmp .obj/shrike.o
+	@mkdir -p runtime/1
 	@mv shrike.tmp runtime/1/shrike.dll
 
 .obj/shrike.o:	shrike.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -338,6 +353,7 @@ runtime/1/shrike.dll:	.obj/shrike.o
 
 runtime/2/area2.dll:	.obj/area2.o
 	$(CC) $(DDFLAGS) -o area2.tmp .obj/area2.o
+	@mkdir -p runtime/2
 	@mv area2.tmp runtime/2/area2.dll
 
 .obj/area2.o:	area2.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -345,6 +361,7 @@ runtime/2/area2.dll:	.obj/area2.o
 
 runtime/3/area3.dll:	.obj/area3.o
 	$(CC) $(DDFLAGS) -o area3.tmp .obj/area3.o
+	@mkdir -p runtime/3
 	@mv area3.tmp runtime/3/area3.dll
 
 .obj/area3.o:	area3.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -352,6 +369,7 @@ runtime/3/area3.dll:	.obj/area3.o
 
 runtime/37/arkhata.dll:	.obj/arkhata.o
 	$(CC) $(DDFLAGS) -o arkhata.tmp .obj/arkhata.o
+	@mkdir -p runtime/37
 	@mv arkhata.tmp runtime/37/arkhata.dll
 
 .obj/arkhata.o:	arkhata.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -359,6 +377,7 @@ runtime/37/arkhata.dll:	.obj/arkhata.o
 
 runtime/22/lab2.dll:	.obj/lab2.o
 	$(CC) $(DDFLAGS) -o lab2.tmp .obj/lab2.o
+	@mkdir -p runtime/22
 	@mv lab2.tmp runtime/22/lab2.dll
 
 .obj/lab2.o:	lab2.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -366,6 +385,7 @@ runtime/22/lab2.dll:	.obj/lab2.o
 
 runtime/22/lab3.dll:	.obj/lab3.o
 	$(CC) $(DDFLAGS) -o lab3.tmp .obj/lab3.o
+	@mkdir -p runtime/22
 	@mv lab3.tmp runtime/22/lab3.dll
 
 .obj/lab3.o:	lab3.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -373,6 +393,7 @@ runtime/22/lab3.dll:	.obj/lab3.o
 
 runtime/22/lab4.dll:	.obj/lab4.o
 	$(CC) $(DDFLAGS) -o lab4.tmp .obj/lab4.o
+	@mkdir -p runtime/22
 	@mv lab4.tmp runtime/22/lab4.dll
 
 .obj/lab4.o:	lab4.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -380,6 +401,7 @@ runtime/22/lab4.dll:	.obj/lab4.o
 
 runtime/22/lab5.dll:	.obj/lab5.o
 	$(CC) $(DDFLAGS) -o lab5.tmp .obj/lab5.o
+	@mkdir -p runtime/22
 	@mv lab5.tmp runtime/22/lab5.dll
 
 .obj/lab5.o:	lab5.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -388,6 +410,7 @@ runtime/22/lab5.dll:	.obj/lab5.o
 
 runtime/3/arena.dll:	.obj/arena.o
 	$(CC) $(DDFLAGS) -o arena.tmp .obj/arena.o
+	@mkdir -p runtime/3
 	@mv arena.tmp runtime/3/arena.dll
 
 .obj/arena.o:	arena.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -395,6 +418,7 @@ runtime/3/arena.dll:	.obj/arena.o
 
 runtime/3/gatekeeper.dll:	.obj/gatekeeper.o
 	$(CC) $(DDFLAGS) -o gatekeeper.tmp .obj/gatekeeper.o
+	@mkdir -p runtime/3
 	@mv gatekeeper.tmp runtime/3/gatekeeper.dll
 
 .obj/gatekeeper.o:	gatekeeper.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -403,7 +427,9 @@ runtime/3/gatekeeper.dll:	.obj/gatekeeper.o
 runtime/3/military.dll:	.obj/military.o
 	$(CC) $(DDFLAGS) -o military.tmp .obj/military.o
 	@cp military.tmp military.tmp2
+	@mkdir -p runtime/3
 	@mv military.tmp runtime/3/military.dll
+	@mkdir -p runtime/29
 	@mv military.tmp2 runtime/29/military.dll
 
 .obj/military.o:	military.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -411,6 +437,7 @@ runtime/3/military.dll:	.obj/military.o
 
 runtime/6/edemon.dll:	.obj/edemon.o
 	$(CC) $(DDFLAGS) -o edemon.tmp .obj/edemon.o
+	@mkdir -p runtime/6
 	@mv edemon.tmp runtime/6/edemon.dll
 
 .obj/edemon.o:	edemon.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -418,6 +445,7 @@ runtime/6/edemon.dll:	.obj/edemon.o
 
 runtime/5/sewers.dll:	.obj/sewers.o
 	$(CC) $(DDFLAGS) -o sewers.tmp .obj/sewers.o
+	@mkdir -p runtime/5
 	@mv sewers.tmp runtime/5/sewers.dll
 
 .obj/sewers.o:	sewers.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -425,6 +453,7 @@ runtime/5/sewers.dll:	.obj/sewers.o
 
 runtime/8/fdemon.dll:	.obj/fdemon.o
 	$(CC) $(DDFLAGS) -o fdemon.tmp .obj/fdemon.o
+	@mkdir -p runtime/8
 	@mv fdemon.tmp runtime/8/fdemon.dll
 
 .obj/fdemon.o:	fdemon.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -432,6 +461,7 @@ runtime/8/fdemon.dll:	.obj/fdemon.o
 
 runtime/10/ice.dll:	.obj/ice.o
 	$(CC) $(DDFLAGS) -o ice.tmp .obj/ice.o
+	@mkdir -p runtime/10
 	@mv ice.tmp runtime/10/ice.dll
 
 .obj/ice.o:	ice.c ice_shared.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -439,6 +469,7 @@ runtime/10/ice.dll:	.obj/ice.o
 
 runtime/11/palace.dll:	.obj/palace.o
 	$(CC) $(DDFLAGS) -o palace.tmp .obj/palace.o
+	@mkdir -p runtime/11
 	@mv palace.tmp runtime/11/palace.dll
 
 .obj/palace.o:	palace.c ice_shared.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -446,6 +477,7 @@ runtime/11/palace.dll:	.obj/palace.o
 
 runtime/13/dungeon.dll:	.obj/dungeon.o
 	$(CC) $(DDFLAGS) -o dungeon.tmp .obj/dungeon.o
+	@mkdir -p runtime/13
 	@mv dungeon.tmp runtime/13/dungeon.dll
 
 .obj/dungeon.o:	dungeon.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -453,6 +485,7 @@ runtime/13/dungeon.dll:	.obj/dungeon.o
 
 runtime/14/random.dll:	.obj/random.o
 	$(CC) $(DDFLAGS) -o random.tmp .obj/random.o
+	@mkdir -p runtime/14
 	@mv random.tmp runtime/14/random.dll
 
 .obj/random.o:	random.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -460,6 +493,7 @@ runtime/14/random.dll:	.obj/random.o
 
 runtime/15/swamp.dll:	.obj/swamp.o
 	$(CC) $(DDFLAGS) -o swamp.tmp .obj/swamp.o
+	@mkdir -p runtime/15
 	@mv swamp.tmp runtime/15/swamp.dll
 
 .obj/swamp.o:	swamp.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -467,6 +501,7 @@ runtime/15/swamp.dll:	.obj/swamp.o
 
 runtime/16/forest.dll:	.obj/forest.o
 	$(CC) $(DDFLAGS) -o forest.tmp .obj/forest.o
+	@mkdir -p runtime/16
 	@mv forest.tmp runtime/16/forest.dll
 
 .obj/forest.o:	forest.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -474,6 +509,7 @@ runtime/16/forest.dll:	.obj/forest.o
 
 runtime/17/two.dll:	.obj/two.o
 	$(CC) $(DDFLAGS) -o two.tmp .obj/two.o
+	@mkdir -p runtime/17
 	@mv two.tmp runtime/17/two.dll
 
 .obj/two.o:	two.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -481,6 +517,7 @@ runtime/17/two.dll:	.obj/two.o
 
 runtime/18/bones.dll:	.obj/bones.o
 	$(CC) $(DDFLAGS) -o bones.tmp .obj/bones.o
+	@mkdir -p runtime/18
 	@mv bones.tmp runtime/18/bones.dll
 
 .obj/bones.o:	bones.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -488,6 +525,7 @@ runtime/18/bones.dll:	.obj/bones.o
 
 runtime/19/nomad.dll:	.obj/nomad.o
 	$(CC) $(DDFLAGS) -o nomad.tmp .obj/nomad.o
+	@mkdir -p runtime/19
 	@mv nomad.tmp runtime/19/nomad.dll
 
 .obj/nomad.o:	nomad.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -495,6 +533,7 @@ runtime/19/nomad.dll:	.obj/nomad.o
 
 runtime/19/saltmine.dll:	.obj/saltmine.o
 	$(CC) $(DDFLAGS) -o saltmine.tmp .obj/saltmine.o
+	@mkdir -p runtime/19
 	@mv saltmine.tmp runtime/19/saltmine.dll
 
 .obj/saltmine.o:	saltmine.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -502,6 +541,7 @@ runtime/19/saltmine.dll:	.obj/saltmine.o
 
 runtime/26/staffer.dll:	.obj/staffer.o
 	$(CC) $(DDFLAGS) -o staffer.tmp .obj/staffer.o
+	@mkdir -p runtime/26
 	@mv staffer.tmp runtime/26/staffer.dll
 
 .obj/staffer.o:	staffer.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -509,6 +549,7 @@ runtime/26/staffer.dll:	.obj/staffer.o
 
 runtime/29/staffer2.dll:	.obj/staffer2.o
 	$(CC) $(DDFLAGS) -o staffer2.tmp .obj/staffer2.o
+	@mkdir -p runtime/29
 	@mv staffer2.tmp runtime/29/staffer2.dll
 
 .obj/staffer2.o:	staffer2.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -516,6 +557,7 @@ runtime/29/staffer2.dll:	.obj/staffer2.o
 
 runtime/28/staffer3.dll:	.obj/staffer3.o
 	$(CC) $(DDFLAGS) -o staffer3.tmp .obj/staffer3.o
+	@mkdir -p runtime/28
 	@mv staffer3.tmp runtime/28/staffer3.dll
 
 .obj/staffer3.o:	staffer3.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -523,6 +565,7 @@ runtime/28/staffer3.dll:	.obj/staffer3.o
 
 runtime/25/warped.dll:	.obj/warped.o
 	$(CC) $(DDFLAGS) -o warped.tmp .obj/warped.o
+	@mkdir -p runtime/25
 	@mv warped.tmp runtime/25/warped.dll
 
 .obj/warped.o:	warped.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -531,7 +574,9 @@ runtime/25/warped.dll:	.obj/warped.o
 runtime/20/lq.dll:	.obj/lq.o
 	$(CC) $(DDFLAGS) -o lq.tmp .obj/lq.o
 	@cp lq.tmp lq.tmpx
+	@mkdir -p runtime/35
 	@mv lq.tmpx runtime/35/lq.dll
+	@mkdir -p runtime/20
 	@mv lq.tmp runtime/20/lq.dll
 
 .obj/lq.o:	lq.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -539,6 +584,7 @@ runtime/20/lq.dll:	.obj/lq.o
 
 runtime/generic/mine.dll:	.obj/mine.o
 	$(CC) $(DDFLAGS) -o mine.tmp .obj/mine.o
+	@mkdir -p runtime/generic
 	@mv mine.tmp runtime/generic/mine.dll
 
 .obj/mine.o:	mine.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -546,6 +592,7 @@ runtime/generic/mine.dll:	.obj/mine.o
 
 runtime/22/lab1.dll:		.obj/lab1.o
 	$(CC) $(DDFLAGS) -o lab1.tmp .obj/lab1.o
+	@mkdir -p runtime/22
 	@mv lab1.tmp runtime/22/lab1.dll
 
 .obj/lab1.o:	lab1.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -554,7 +601,9 @@ runtime/22/lab1.dll:		.obj/lab1.o
 runtime/23/strategy.dll: 	.obj/strategy.o
 	$(CC) $(DDFLAGS) -o strategy.tmp .obj/strategy.o
 	@cp strategy.tmp strategy2.tmp
+	@mkdir -p runtime/23
 	@mv strategy.tmp runtime/23/strategy.dll
+	@mkdir -p runtime/24
 	@mv strategy2.tmp runtime/24/strategy.dll
 
 .obj/strategy.o:	strategy.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -562,6 +611,7 @@ runtime/23/strategy.dll: 	.obj/strategy.o
 
 runtime/33/tunnel.dll: 	.obj/tunnel.o
 	$(CC) $(DDFLAGS) -o tunnel.tmp .obj/tunnel.o
+	@mkdir -p runtime/33
 	@mv tunnel.tmp runtime/33/tunnel.dll
 
 .obj/tunnel.o:	tunnel.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -569,6 +619,7 @@ runtime/33/tunnel.dll: 	.obj/tunnel.o
 
 runtime/31/warrmines.dll: .obj/warrmines.o
 	$(CC) $(DDFLAGS) -o warrmines.tmp .obj/warrmines.o
+	@mkdir -p runtime/31
 	@mv warrmines.tmp runtime/31/warrmines.dll
 
 .obj/warrmines.o:	warrmines.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h
@@ -576,6 +627,7 @@ runtime/31/warrmines.dll: .obj/warrmines.o
 
 runtime/32/missions.dll: .obj/missions.o
 	$(CC) $(DDFLAGS) -o missions.tmp .obj/missions.o
+	@mkdir -p runtime/32
 	@mv missions.tmp runtime/32/missions.dll
 
 .obj/missions.o:	missions.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h mission_ppd.h
@@ -583,6 +635,7 @@ runtime/32/missions.dll: .obj/missions.o
 
 runtime/34/teufel.dll: .obj/teufel.o
 	$(CC) $(DDFLAGS) -o teufel.tmp .obj/teufel.o
+	@mkdir -p runtime/34
 	@mv teufel.tmp runtime/34/teufel.dll
 
 .obj/teufel.o:	teufel.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h mission_ppd.h
@@ -590,6 +643,7 @@ runtime/34/teufel.dll: .obj/teufel.o
 
 runtime/36/caligar.dll: .obj/caligar.o
 	$(CC) $(DDFLAGS) -o caligar.tmp .obj/caligar.o
+	@mkdir -p runtime/36
 	@mv caligar.tmp runtime/36/caligar.dll
 
 .obj/caligar.o:	caligar.c server.h log.h notify.h do.h direction.h path.h error.h drdata.h see.h drvlib.h death.h effect.h tool.h store.h area1.h

--- a/server.c
+++ b/server.c
@@ -91,6 +91,7 @@ rec_bytes=0;        // bytes sent
 
 
 struct character *ch;
+struct effect *ef;
 struct item *it;
 struct map *map;
 

--- a/server.h
+++ b/server.h
@@ -536,7 +536,9 @@ struct effect
 	int number_of_enemies;		// number of enemies hit by effect last tick
 
 	int base_sprite;		// for explosion: sprite number
-} *ef;
+};
+
+extern struct effect *ef;
 
 // *********** BASIC LIBRARY ******************
 unsigned long long prof_start(int task);


### PR DESCRIPTION
Fix some build errors when compiling on linux

- `ef` was being defined in `server.h` which lead to duplicate symbol errors. Move it to `server.c` to match `ch` and other globals
- `Makefile` was assuming that the `runtime` folder and various subfolders exist already. Added silent mkdir to create the requisite directories before doing the `mv`