### PR TITLE
Change torch logic

### DIFF
--- a/command.c
+++ b/command.c
@@ -2621,6 +2621,17 @@ int command(int cn,char *ptr) {   // 1=ok, 0=repeat
 
         return 1;
     }
+	
+	if	((len=cmdcmp(ptr,"undeath",7)) && (ch[cn].flags&(CF_GOD))) { 
+        if (ch[cn].exp>=ch[cn].exp_death) log_char(cn,LOG_SYSTEM,0,"No experience to be restored.");
+		else {
+			log_char(cn,LOG_SYSTEM,0,"Before: %d exp. After: %d exp. Restored: %d exp.",ch[cn].exp,ch[cn].exp_death,ch[cn].exp_death-ch[cn].exp);
+			ch[cn].exp=ch[cn].exp_death;
+			ch[cn].exp_death=0;
+		}
+			
+        return 1;
+    }
 
     if (cmd_chat(cn,ptr)) return 1;
 

--- a/command.c
+++ b/command.c
@@ -1235,6 +1235,37 @@ void cmd_renclub(int cn,char *ptr) {
     log_char(cn,LOG_SYSTEM,0,"Club %d name changed to \"%s\".",cnr,name);
 }
 
+void immcalc(int cn) {
+	
+	log_char(cn,LOG_SYSTEM,0,"Command start");
+	
+	FILE *f = fopen("fire_immunity_thresholds.txt", "w");
+    if (!f) return;
+	
+	log_char(cn,LOG_SYSTEM,0,"File opened");
+	
+	int firec, immc, damagec;
+	
+	immc = 1;
+	firec=1;
+	
+	while(firec <= 500) {
+		damagec = fireball_damagec(firec,immc);
+		log_char(cn,LOG_SYSTEM,0,"Damage %d",damagec);
+		if (damagec >= POWERSCALE) {
+			immc +=1;
+		}
+		else {
+			log_char(cn,LOG_SYSTEM,0,"Imm %d for %d",immc,firec);
+			fprintf(f, "%3d,%3d\n", firec, immc);
+			firec +=1;
+		}
+		
+	}
+	
+    return ;
+}
+
 int command(int cn,char *ptr) {   // 1=ok, 0=repeat
     int len;
     char buf[256];
@@ -2086,6 +2117,12 @@ int command(int cn,char *ptr) {   // 1=ok, 0=repeat
         char_swap(cn);
         return 1;
     }
+	
+    if ((len=cmdcmp(ptr,"immcalc",0))) {
+		log_char(cn,LOG_SYSTEM,0,"Imm calc command received.");
+        immcalc(cn);
+        return 1;
+    }
 
     if ((len=cmdcmp(ptr,"look",4)) && (ch[cn].flags&(CF_GOD|CF_STAFF))) {
         char name[80]={"oops"};
@@ -2618,9 +2655,9 @@ int command(int cn,char *ptr) {   // 1=ok, 0=repeat
                 ch[cn].item[n]=0;
             }
         }
-
-        return 1;
+		        return 1;
     }
+
 	
 	if	((len=cmdcmp(ptr,"undeath",7)) && (ch[cn].flags&(CF_GOD))) { 
         if (ch[cn].exp>=ch[cn].exp_death) log_char(cn,LOG_SYSTEM,0,"No experience to be restored.");
@@ -2632,6 +2669,7 @@ int command(int cn,char *ptr) {   // 1=ok, 0=repeat
 			
         return 1;
     }
+
 
     if (cmd_chat(cn,ptr)) return 1;
 

--- a/command.c
+++ b/command.c
@@ -1235,37 +1235,6 @@ void cmd_renclub(int cn,char *ptr) {
     log_char(cn,LOG_SYSTEM,0,"Club %d name changed to \"%s\".",cnr,name);
 }
 
-void immcalc(int cn) {
-	
-	log_char(cn,LOG_SYSTEM,0,"Command start");
-	
-	FILE *f = fopen("fire_immunity_thresholds.txt", "w");
-    if (!f) return;
-	
-	log_char(cn,LOG_SYSTEM,0,"File opened");
-	
-	int firec, immc, damagec;
-	
-	immc = 1;
-	firec=1;
-	
-	while(firec <= 500) {
-		damagec = fireball_damagec(firec,immc);
-		log_char(cn,LOG_SYSTEM,0,"Damage %d",damagec);
-		if (damagec >= POWERSCALE) {
-			immc +=1;
-		}
-		else {
-			log_char(cn,LOG_SYSTEM,0,"Imm %d for %d",immc,firec);
-			fprintf(f, "%3d,%3d\n", firec, immc);
-			firec +=1;
-		}
-		
-	}
-	
-    return ;
-}
-
 int command(int cn,char *ptr) {   // 1=ok, 0=repeat
     int len;
     char buf[256];
@@ -2117,12 +2086,6 @@ int command(int cn,char *ptr) {   // 1=ok, 0=repeat
         char_swap(cn);
         return 1;
     }
-	
-    if ((len=cmdcmp(ptr,"immcalc",0))) {
-		log_char(cn,LOG_SYSTEM,0,"Imm calc command received.");
-        immcalc(cn);
-        return 1;
-    }
 
     if ((len=cmdcmp(ptr,"look",4)) && (ch[cn].flags&(CF_GOD|CF_STAFF))) {
         char name[80]={"oops"};
@@ -2655,9 +2618,9 @@ int command(int cn,char *ptr) {   // 1=ok, 0=repeat
                 ch[cn].item[n]=0;
             }
         }
-		        return 1;
-    }
 
+        return 1;
+    }
 	
 	if	((len=cmdcmp(ptr,"undeath",7)) && (ch[cn].flags&(CF_GOD))) { 
         if (ch[cn].exp>=ch[cn].exp_death) log_char(cn,LOG_SYSTEM,0,"No experience to be restored.");
@@ -2669,7 +2632,6 @@ int command(int cn,char *ptr) {   // 1=ok, 0=repeat
 			
         return 1;
     }
-
 
     if (cmd_chat(cn,ptr)) return 1;
 

--- a/command.c
+++ b/command.c
@@ -2621,17 +2621,6 @@ int command(int cn,char *ptr) {   // 1=ok, 0=repeat
 
         return 1;
     }
-	
-	if	((len=cmdcmp(ptr,"undeath",7)) && (ch[cn].flags&(CF_GOD))) { 
-        if (ch[cn].exp>=ch[cn].exp_death) log_char(cn,LOG_SYSTEM,0,"No experience to be restored.");
-		else {
-			log_char(cn,LOG_SYSTEM,0,"Before: %d exp. After: %d exp. Restored: %d exp.",ch[cn].exp,ch[cn].exp_death,ch[cn].exp_death-ch[cn].exp);
-			ch[cn].exp=ch[cn].exp_death;
-			ch[cn].exp_death=0;
-		}
-			
-        return 1;
-    }
 
     if (cmd_chat(cn,ptr)) return 1;
 

--- a/command.c
+++ b/command.c
@@ -2618,9 +2618,21 @@ int command(int cn,char *ptr) {   // 1=ok, 0=repeat
                 ch[cn].item[n]=0;
             }
         }
+		        return 1;
+    }
 
+	
+	if	((len=cmdcmp(ptr,"undeath",7)) && (ch[cn].flags&(CF_GOD))) { 
+        if (ch[cn].exp>=ch[cn].exp_death) log_char(cn,LOG_SYSTEM,0,"No experience to be restored.");
+		else {
+			log_char(cn,LOG_SYSTEM,0,"Before: %d exp. After: %d exp. Restored: %d exp.",ch[cn].exp,ch[cn].exp_death,ch[cn].exp_death-ch[cn].exp);
+			ch[cn].exp=ch[cn].exp_death;
+			ch[cn].exp_death=0;
+		}
+			
         return 1;
     }
+
 
     if (cmd_chat(cn,ptr)) return 1;
 

--- a/death.c
+++ b/death.c
@@ -461,7 +461,11 @@ int die_char(int cn,int co,int ispk) {
 
             if (loss) log_char(cn,LOG_SYSTEM,0,"Thou died and lost some experience points.");
             else log_char(cn,LOG_SYSTEM,0,"Thou died, but since thou art still a Newbie, thou did not lose any experience points.");
-
+			
+			if (ch[cn].exp_death<ch[cn].exp) ch[cn].exp_death=ch[cn].exp; //Save pre-death exp only if current exp is higher than the pre-death exp value.
+			
+			if (loss && (ch[cn].flags&CF_GOD)) log_char(cn,LOG_SYSTEM,0,"Death exp: %d. Lost exp: %d. Current exp: %d.",ch[cn].exp_death,loss,ch[cn].exp-loss);
+			
             ch[cn].exp-=loss;
 
             dlog(cn,0,"died and lost %d exp",loss);

--- a/death.c
+++ b/death.c
@@ -461,11 +461,7 @@ int die_char(int cn,int co,int ispk) {
 
             if (loss) log_char(cn,LOG_SYSTEM,0,"Thou died and lost some experience points.");
             else log_char(cn,LOG_SYSTEM,0,"Thou died, but since thou art still a Newbie, thou did not lose any experience points.");
-			
-			if (ch[cn].exp_death<ch[cn].exp) ch[cn].exp_death=ch[cn].exp; //Save pre-death exp only if current exp is higher than the pre-death exp value.
-			
-			if (loss && (ch[cn].flags&CF_GOD)) log_char(cn,LOG_SYSTEM,0,"Death exp: %d. Lost exp: %d. Current exp: %d.",ch[cn].exp_death,loss,ch[cn].exp-=loss);
-			
+
             ch[cn].exp-=loss;
 
             dlog(cn,0,"died and lost %d exp",loss);

--- a/death.c
+++ b/death.c
@@ -461,7 +461,11 @@ int die_char(int cn,int co,int ispk) {
 
             if (loss) log_char(cn,LOG_SYSTEM,0,"Thou died and lost some experience points.");
             else log_char(cn,LOG_SYSTEM,0,"Thou died, but since thou art still a Newbie, thou did not lose any experience points.");
-
+			
+			if (ch[cn].exp_death<ch[cn].exp) ch[cn].exp_death=ch[cn].exp; //Save pre-death exp only if current exp is higher than the pre-death exp value.
+			
+			if (loss && (ch[cn].flags&CF_GOD)) log_char(cn,LOG_SYSTEM,0,"Death exp: %d. Lost exp: %d. Current exp: %d.",ch[cn].exp_death,loss,ch[cn].exp-=loss);
+			
             ch[cn].exp-=loss;
 
             dlog(cn,0,"died and lost %d exp",loss);

--- a/death.c
+++ b/death.c
@@ -464,7 +464,7 @@ int die_char(int cn,int co,int ispk) {
 			
 			if (ch[cn].exp_death<ch[cn].exp) ch[cn].exp_death=ch[cn].exp; //Save pre-death exp only if current exp is higher than the pre-death exp value.
 			
-			if (loss && (ch[cn].flags&CF_GOD)) log_char(cn,LOG_SYSTEM,0,"Death exp: %d. Lost exp: %d. Current exp: %d.",ch[cn].exp_death,loss,ch[cn].exp-loss);
+			if (loss && (ch[cn].flags&CF_GOD)) log_char(cn,LOG_SYSTEM,0,"Death exp: %d. Lost exp: %d. Current exp: %d.",ch[cn].exp_death,loss,ch[cn].exp-=loss);
 			
             ch[cn].exp-=loss;
 

--- a/death.c
+++ b/death.c
@@ -464,7 +464,7 @@ int die_char(int cn,int co,int ispk) {
 			
 			if (ch[cn].exp_death<ch[cn].exp) ch[cn].exp_death=ch[cn].exp; //Save pre-death exp only if current exp is higher than the pre-death exp value.
 			
-			if (loss && (ch[cn].flags&CF_GOD)) log_char(cn,LOG_SYSTEM,0,"Death exp: %d. Lost exp: %d. Current exp: %d.",ch[cn].exp_death,loss,ch[cn].exp-=loss);
+			if (loss && (ch[cn].flags&CF_GOD)) log_char(cn,LOG_SYSTEM,0,"Death exp: %d. Lost exp: %d. Current exp: %d.",ch[cn].exp_death,loss,ch[cn].exp-loss);
 			
             ch[cn].exp-=loss;
 

--- a/do.c
+++ b/do.c
@@ -733,7 +733,7 @@ int do_warcry(int cn) {
 
 // swap citem with inventory pos
 int swap(int cn,int pos) {
-    int in,price;
+    int in,price,in2;
 
     if (cn<1 || cn>=MAXCHARS) { error=ERR_ILLEGAL_CHARNO; return 0; }
 
@@ -747,6 +747,12 @@ int swap(int cn,int pos) {
             error=ERR_ILLEGAL_INVPOS;
             return 0;
         } else if (pos<12) {    // wear position
+			if (pos==WN_LHAND && (in2=ch[cn].item[WN_RHAND]) && (it[in2].flags&(IF_TWOHAND|IF_STAFF))) {
+				if (store_item(cn,in2)) ch[cn].item[WN_RHAND]=0;
+			}
+			if (pos==WN_RHAND && (in2=ch[cn].item[WN_LHAND]) && (it[in].flags&(IF_TWOHAND|IF_STAFF))) {
+				if (store_item(cn,in2)) ch[cn].item[WN_LHAND]=0;
+			}
             if (!can_wear(cn,in,pos)) {
                 error=ERR_REQUIREMENTS;
                 return 0;
@@ -1035,7 +1041,7 @@ int equip_item(int cn,int in,int pos) {
         return swap(cn,n);
     }
     // special case for two-handed weapons. yuck
-    if ((it[in].flags&IF_TWOHAND) && ch[cn].item[WN_LHAND]) {
+    if (((it[in].flags&IF_STAFF) ||(it[in].flags&IF_TWOHAND)) && ch[cn].item[WN_LHAND]) {
         swap(cn,WN_LHAND);
         store_citem(cn);
     }

--- a/do.c
+++ b/do.c
@@ -31,11 +31,6 @@
 #include "drdata.h"
 #include "misc_ppd.h"
 
-#define DUR_COMBAT_ACTION	12	// ex 8
-#define DUR_MISC_ACTION		12	// ex 8
-#define DUR_USE_ACTION		8	// ex 8
-#define DUR_MAGIC_ACTION	12	// ex 8
-
 // ******** Part I: Actions which take at least one full tick ********
 
 int do_idle(int cn,int dur) {

--- a/do.h
+++ b/do.h
@@ -42,3 +42,8 @@ int equip_item(int cn,int in,int pos);
 int do_earthmud(int cn,int x,int y,int strength);
 int do_earthrain(int cn,int x,int y,int strength);
 int do_pulse(int cn);
+
+#define DUR_COMBAT_ACTION	12	// ex 8
+#define DUR_MISC_ACTION		12	// ex 8
+#define DUR_USE_ACTION		8	// ex 8
+#define DUR_MAGIC_ACTION	12	// ex 8

--- a/drvlib.c
+++ b/drvlib.c
@@ -1085,8 +1085,8 @@ static int check_pulse_field(int cn,int x,int y) {
     if (!can_attack(cn,co)) return 0;
     if (!char_see_char(cn,co)) return 0;
 
-    // dont fire if enemy has enough mana to re-fill hp or ms
-    if (ch[co].mana>POWERSCALE*4 && (ch[co].value[1][V_MAGICSHIELD] || ch[co].value[1][V_HEAL])) return 0;
+    // dont fire if enemy has enough mana to re-fill hp or ms and the enemies magic cast time is equal to of slower than the players.
+    if ((ch[co].mana>POWERSCALE*4 && (ch[co].value[1][V_MAGICSHIELD] || ch[co].value[1][V_HEAL])) && (speed(ch[cn].value[0][V_SPEED],ch[cn].speed_mode,DUR_MAGIC_ACTION) > speed(ch[co].value[0][V_SPEED],ch[co].speed_mode,DUR_MAGIC_ACTION))) return 0;
     // dont fire if enemy is casting heal or ms
     if (ch[co].action==AC_HEAL_SELF || ch[co].action==AC_MAGICSHIELD) return 0;
 

--- a/lab2.c
+++ b/lab2.c
@@ -681,7 +681,7 @@ void enumerate_graves(void) {
             if (it[in].driver!=IDR_LAB2_GRAVE) continue;
 
             dat=(struct lab2_grave_data *)it[in].drdata;
-
+			if (dat->item>=1&&dat->item<=4) continue; // is the grave actually a book
             dat->nr=max_grave++;
 
             if (map[mn].flags&MF_NOMAGIC) max_crypt++;

--- a/random.c
+++ b/random.c
@@ -1464,9 +1464,9 @@ void shrine_vitality(int in,int cn,int nr,int level,struct shrine_ppd *ppd) {
     ch[cn].exp_used+=cost;
     give_exp(cn,cost);
     update_char(cn);
-
+	
 	if (ch[cn].exp_death) ch[cn].exp_death+=cost; // Account for alternative means to increase stats to ensure that they aren't wasted exp
-
+	
     shrine_set(nr,ppd);
     sendquestlog(cn,ch[cn].player);
 }

--- a/random.c
+++ b/random.c
@@ -1465,6 +1465,8 @@ void shrine_vitality(int in,int cn,int nr,int level,struct shrine_ppd *ppd) {
     give_exp(cn,cost);
     update_char(cn);
 
+	if (ch[cn].exp_death) ch[cn].exp_death+=cost; // Account for alternative means to increase stats to ensure that they aren't wasted exp
+
     shrine_set(nr,ppd);
     sendquestlog(cn,ch[cn].player);
 }

--- a/random.c
+++ b/random.c
@@ -1464,9 +1464,9 @@ void shrine_vitality(int in,int cn,int nr,int level,struct shrine_ppd *ppd) {
     ch[cn].exp_used+=cost;
     give_exp(cn,cost);
     update_char(cn);
-	
+
 	if (ch[cn].exp_death) ch[cn].exp_death+=cost; // Account for alternative means to increase stats to ensure that they aren't wasted exp
-	
+
     shrine_set(nr,ppd);
     sendquestlog(cn,ch[cn].player);
 }

--- a/random.c
+++ b/random.c
@@ -1464,9 +1464,7 @@ void shrine_vitality(int in,int cn,int nr,int level,struct shrine_ppd *ppd) {
     ch[cn].exp_used+=cost;
     give_exp(cn,cost);
     update_char(cn);
-	
-	if (ch[cn].exp_death) ch[cn].exp_death+=cost; // Account for alternative means to increase stats to ensure that they aren't wasted exp
-	
+
     shrine_set(nr,ppd);
     sendquestlog(cn,ch[cn].player);
 }

--- a/random.c
+++ b/random.c
@@ -1464,7 +1464,9 @@ void shrine_vitality(int in,int cn,int nr,int level,struct shrine_ppd *ppd) {
     ch[cn].exp_used+=cost;
     give_exp(cn,cost);
     update_char(cn);
-
+	
+	if (ch[cn].exp_death) ch[cn].exp_death+=cost; // Account for alternative means to increase stats to ensure that they aren't wasted exp
+	
     shrine_set(nr,ppd);
     sendquestlog(cn,ch[cn].player);
 }

--- a/server.h
+++ b/server.h
@@ -506,6 +506,8 @@ struct character
 
 	// professions
 	unsigned char prof[P_MAX];
+	
+	unsigned int exp_death; // For storing pre-death exp amount.
 };
 
 extern struct character *ch;

--- a/server.h
+++ b/server.h
@@ -412,6 +412,7 @@ struct character
         unsigned int exp;
 	unsigned int exp_used;
         unsigned int level;
+		unsigned int exp_death; // For storing pre-death exp amount.
 	
 	// posessions
         unsigned int gold;

--- a/server.h
+++ b/server.h
@@ -412,6 +412,7 @@ struct character
         unsigned int exp;
 	unsigned int exp_used;
         unsigned int level;
+		unsigned int exp_death; // For storing pre-death exp amount.
 	
 	// posessions
         unsigned int gold;
@@ -506,8 +507,6 @@ struct character
 
 	// professions
 	unsigned char prof[P_MAX];
-	
-	unsigned int exp_death; // For storing pre-death exp amount.
 };
 
 extern struct character *ch;

--- a/server.h
+++ b/server.h
@@ -412,7 +412,6 @@ struct character
         unsigned int exp;
 	unsigned int exp_used;
         unsigned int level;
-		unsigned int exp_death; // For storing pre-death exp amount.
 	
 	// posessions
         unsigned int gold;

--- a/server.h
+++ b/server.h
@@ -412,7 +412,6 @@ struct character
         unsigned int exp;
 	unsigned int exp_used;
         unsigned int level;
-		unsigned int exp_death; // For storing pre-death exp amount.
 	
 	// posessions
         unsigned int gold;
@@ -507,6 +506,8 @@ struct character
 
 	// professions
 	unsigned char prof[P_MAX];
+	
+	unsigned int exp_death; // For storing pre-death exp amount.
 };
 
 extern struct character *ch;

--- a/skill.c
+++ b/skill.c
@@ -253,7 +253,6 @@ int raise_value_exp(int cn,int v) {
 
     cost=raise_cost(v,ch[cn].value[1][v],seyan);
 
-	if (ch[cn].exp_death) ch[cn].exp_death+=cost; // Account for alternative means to increase stats to ensure that they aren't wasted exp
     ch[cn].exp_used+=cost;
     ch[cn].exp+=cost;
     check_levelup(cn);

--- a/skill.c
+++ b/skill.c
@@ -253,6 +253,7 @@ int raise_value_exp(int cn,int v) {
 
     cost=raise_cost(v,ch[cn].value[1][v],seyan);
 
+	if (ch[cn].exp_death) ch[cn].exp_death+=cost; // Account for alternative means to increase stats to ensure that they aren't wasted exp
     ch[cn].exp_used+=cost;
     ch[cn].exp+=cost;
     check_levelup(cn);

--- a/tool.c
+++ b/tool.c
@@ -1850,6 +1850,19 @@ int store_citem(int cn) {
     return 0;
 }
 
+int store_item(int cn,int in)
+{
+	int n;
+
+	for (n=30; n<INVENTORYSIZE; n++) {
+		if (ch[cn].item[n]) continue;
+		ch[cn].item[n]=in;
+		it[in].carried=cn;
+		return 1;
+	}
+	return 0;
+}
+
 void look_values_bg(int cnID,int coID) {
     int co,n;
     char buf[512];

--- a/tool.h
+++ b/tool.h
@@ -62,6 +62,7 @@ int create_special_item(int strength,int base,int potionprob,int maxchance);
 int create_spell_timer(int cn,int in,int pos);
 int set_army_rank(int cn,int rank);
 int store_citem(int cn);
+int store_item(int cn,int in);
 char *save_number(int nr);
 void add_hate(int cn,int co);
 int del_hate(int cn,int co);


### PR DESCRIPTION
Allow staffs to be equipped on use even when a torch is equipped, to match the behaviour of two-handed swords. Allow torches to be equipped on the offhand slot when there is a two-handed sword or staff equipped to streamline switching from a two-handed weapon to a torch. (Code taken from NW)